### PR TITLE
Use .allowHDR instead of .hdr (deprecated)

### DIFF
--- a/workers/unity/Assets/Standard Assets/Editor/ImageEffects/BloomAndFlaresEditor.cs
+++ b/workers/unity/Assets/Standard Assets/Editor/ImageEffects/BloomAndFlaresEditor.cs
@@ -77,7 +77,7 @@ namespace UnityStandardAssets.ImageEffects
             // display info text when screen blend mode cannot be used
             Camera cam = (target as BloomAndFlares).GetComponent<Camera>();
             if (cam != null) {
-                if (screenBlendMode.enumValueIndex==0 && ((cam.hdr && hdr.enumValueIndex==0) || (hdr.enumValueIndex==1))) {
+                if (screenBlendMode.enumValueIndex==0 && ((cam.allowHDR && hdr.enumValueIndex==0) || (hdr.enumValueIndex==1))) {
                     EditorGUILayout.HelpBox("Screen blend is not supported in HDR. Using 'Add' instead.", MessageType.Info);
                 }
             }

--- a/workers/unity/Assets/Standard Assets/Editor/ImageEffects/BloomEditor.cs
+++ b/workers/unity/Assets/Standard Assets/Editor/ImageEffects/BloomEditor.cs
@@ -85,7 +85,7 @@ namespace UnityStandardAssets.ImageEffects
             // display info text when screen blend mode cannot be used
             Camera cam = (target as Bloom).GetComponent<Camera>();
             if (cam != null) {
-                if (screenBlendMode.enumValueIndex==0 && ((cam.hdr && hdr.enumValueIndex==0) || (hdr.enumValueIndex==1))) {
+                if (screenBlendMode.enumValueIndex==0 && ((cam.allowHDR && hdr.enumValueIndex==0) || (hdr.enumValueIndex==1))) {
                     EditorGUILayout.HelpBox("Screen blend is not supported in HDR. Using 'Add' instead.", MessageType.Info);
                 }
             }

--- a/workers/unity/Assets/Standard Assets/Editor/ImageEffects/TonemappingEditor.cs
+++ b/workers/unity/Assets/Standard Assets/Editor/ImageEffects/TonemappingEditor.cs
@@ -42,7 +42,7 @@ namespace UnityStandardAssets.ImageEffects
 
             Camera cam = (target as Tonemapping).GetComponent<Camera>();
             if (cam != null) {
-                if (!cam.hdr) {
+                if (!cam.allowHDR) {
                     EditorGUILayout.HelpBox("The camera is not HDR enabled. This will likely break the Tonemapper.", MessageType.Warning);
                 }
                 else if (!(target as Tonemapping).validRenderTextureFormat) {

--- a/workers/unity/Assets/Standard Assets/Effects/ImageEffects/Scripts/Bloom.cs
+++ b/workers/unity/Assets/Standard Assets/Effects/ImageEffects/Scripts/Bloom.cs
@@ -106,7 +106,7 @@ namespace UnityStandardAssets.ImageEffects
 
             doHdr = false;
             if (hdr == HDRBloomMode.Auto)
-                doHdr = source.format == RenderTextureFormat.ARGBHalf && GetComponent<Camera>().hdr;
+                doHdr = source.format == RenderTextureFormat.ARGBHalf && GetComponent<Camera>().allowHDR;
             else {
                 doHdr = hdr == HDRBloomMode.On;
             }

--- a/workers/unity/Assets/Standard Assets/Effects/ImageEffects/Scripts/BloomAndFlares.cs
+++ b/workers/unity/Assets/Standard Assets/Effects/ImageEffects/Scripts/BloomAndFlares.cs
@@ -109,7 +109,7 @@ namespace UnityStandardAssets.ImageEffects
 
             doHdr = false;
             if (hdr == HDRBloomMode.Auto)
-                doHdr = source.format == RenderTextureFormat.ARGBHalf && GetComponent<Camera>().hdr;
+                doHdr = source.format == RenderTextureFormat.ARGBHalf && GetComponent<Camera>().allowHDR;
             else
             {
                 doHdr = hdr == HDRBloomMode.On;

--- a/workers/unity/Assets/Standard Assets/Effects/ImageEffects/Scripts/SunShafts.cs
+++ b/workers/unity/Assets/Standard Assets/Effects/ImageEffects/Scripts/SunShafts.cs
@@ -90,7 +90,7 @@ namespace UnityStandardAssets.ImageEffects
             sunShaftsMaterial.SetVector ("_SunThreshold", sunThreshold);
 
             if (!useDepthTexture) {
-                var format= GetComponent<Camera>().hdr ? RenderTextureFormat.DefaultHDR: RenderTextureFormat.Default;
+                var format= GetComponent<Camera>().allowHDR ? RenderTextureFormat.DefaultHDR: RenderTextureFormat.Default;
                 RenderTexture tmpBuffer = RenderTexture.GetTemporary (source.width, source.height, 0, format);
                 RenderTexture.active = tmpBuffer;
                 GL.ClearWithSkybox (false, GetComponent<Camera>());


### PR DESCRIPTION
This fixes 6 warnings that appear when compiling the PiratesTutorial C#/Unity workers